### PR TITLE
feat: integrate lodash for string case transformations

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "packageManager": "pnpm@10.4.1",
   "devDependencies": {
     "@types/figlet": "^1.7.0",
+    "@types/lodash": "^4.17.20",
     "@types/node": "^24.0.10",
     "bun": "^1.2.18",
     "tsx": "^4.20.3",
@@ -53,7 +54,8 @@
     "commander": "^14.0.0",
     "consola": "^3.4.2",
     "figlet": "^1.8.1",
-    "graphql": "^16.11.0"
+    "graphql": "^16.11.0",
+    "lodash": "^4.17.21"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,10 +23,16 @@ importers:
       graphql:
         specifier: ^16.11.0
         version: 16.11.0
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
     devDependencies:
       '@types/figlet':
         specifier: ^1.7.0
         version: 1.7.0
+      '@types/lodash':
+        specifier: ^4.17.20
+        version: 4.17.20
       '@types/node':
         specifier: ^24.0.10
         version: 24.0.10
@@ -273,6 +279,9 @@ packages:
   '@types/figlet@1.7.0':
     resolution: {integrity: sha512-KwrT7p/8Eo3Op/HBSIwGXOsTZKYiM9NpWRBJ5sVjWP/SmlS+oxxRvJht/FNAtliJvja44N3ul1yATgohnVBV0Q==}
 
+  '@types/lodash@4.17.20':
+    resolution: {integrity: sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==}
+
   '@types/node@24.0.10':
     resolution: {integrity: sha512-ENHwaH+JIRTDIEEbDK6QSQntAYGtbvdDXnMXnZaZ6k13Du1dPMmprkEHIL7ok2Wl2aZevetwTAb5S+7yIF+enA==}
 
@@ -322,6 +331,9 @@ packages:
   graphql@16.11.0:
     resolution: {integrity: sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -476,6 +488,8 @@ snapshots:
 
   '@types/figlet@1.7.0': {}
 
+  '@types/lodash@4.17.20': {}
+
   '@types/node@24.0.10':
     dependencies:
       undici-types: 7.8.0
@@ -547,6 +561,8 @@ snapshots:
       resolve-pkg-maps: 1.0.0
 
   graphql@16.11.0: {}
+
+  lodash@4.17.21: {}
 
   resolve-pkg-maps@1.0.0: {}
 

--- a/src/commands/parse/parse.command.ts
+++ b/src/commands/parse/parse.command.ts
@@ -19,6 +19,7 @@ import {
   generateFieldDefinition,
   generateTypeDefinition
 } from '../../utils/graphql-parse.utils'
+import _ from 'lodash'
 
 /**
  * Main execution function for the parse command.
@@ -34,15 +35,12 @@ export default async function execute(
   logger.start('Starting schema parsing...')
   logger.debug('Args =', args)
 
-  const serviceNameCapitalized = `${
-    args.serviceName.charAt(0).toUpperCase() + args.serviceName.slice(1)
-  }`
-  const namespaceCapitalized = `${
-    args.namespace.charAt(0).toUpperCase() + args.namespace.slice(1)
-  }`
+  const serviceNameCapitalized = _.upperFirst(_.camelCase(args.serviceName))
+  const namespaceCapitalized = _.upperFirst(_.camelCase(args.namespace))
+
   const prefix = `${namespaceCapitalized}${serviceNameCapitalized}__`
 
-  const finalSchemaFile = args.outputFile ?? `${args.serviceName}-schema.graphql`
+  const finalSchemaFile = args.outputFile ?? `${_.kebabCase(prefix)}-schema.graphql`
 
   // Read all schema files from the specified directory
   const schemaDirectory = args.directory
@@ -207,37 +205,43 @@ ${
 ${
   mutationDefinitions.length > 0
     ? `type ${namespaceCapitalized}Mutations {
-  ${args.serviceName}: ${namespaceCapitalized}${serviceNameCapitalized}Mutations!
+  ${_.camelCase(
+    args.serviceName
+  )}: ${namespaceCapitalized}${serviceNameCapitalized}Mutations!
 }`
     : ''
 }
 
 type ${namespaceCapitalized}Queries {
-  ${args.serviceName}: ${namespaceCapitalized}${serviceNameCapitalized}Queries!
+  ${_.camelCase(
+    args.serviceName
+  )}: ${namespaceCapitalized}${serviceNameCapitalized}Queries!
 }
 ${
   subscriptionDefinitions.length > 0
     ? `type ${namespaceCapitalized}Subscriptions {
-  ${args.serviceName}: ${namespaceCapitalized}${serviceNameCapitalized}Subscriptions!
+  ${_.camelCase(
+    args.serviceName
+  )}: ${namespaceCapitalized}${serviceNameCapitalized}Subscriptions!
 }`
     : ''
 }
 ${
   mutationDefinitions.length > 0
     ? `type Mutation {
-  ${args.namespace}: ${namespaceCapitalized}Mutations!
+  ${_.camelCase(args.namespace)}: ${namespaceCapitalized}Mutations!
 }`
     : ''
 }
 
 type Query {
-  ${args.namespace}: ${namespaceCapitalized}Queries!
+  ${_.camelCase(args.namespace)}: ${namespaceCapitalized}Queries!
 }
 
 ${
   subscriptionDefinitions.length > 0
     ? `type Subscription {
-  ${args.namespace}: ${namespaceCapitalized}Subscriptions!
+  ${_.camelCase(args.namespace)}: ${namespaceCapitalized}Subscriptions!
 }`
     : ''
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,10 @@
 import { Command } from 'commander'
 import figlet from 'figlet'
+import bigFont from 'figlet/importable-fonts/Big'
+import _ from 'lodash'
 import { version as packageVersion } from '../package.json'
 import parseCommand from './commands/parse/parse.command'
 import { appLogger, ConsolaLogLevel } from './utils/logger.utils'
-import bigFont from 'figlet/importable-fonts/Big'
 
 figlet.parseFont('Big', bigFont)
 


### PR DESCRIPTION
Add lodash and its type definitions to improve string manipulation in the codebase. Replace manual string case transformations with lodash utility methods like upperFirst, camelCase, and kebabCase for more consistent and maintainable code.